### PR TITLE
Add Ruby 2.0.0 and 2.1.2 to Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,4 @@ rvm:
   - 2.0.0
   - 2.1.2
   - ree
-  - rbx
-  - rbx-2.0
   - jruby


### PR DESCRIPTION
Would be great to know that Ruby 2.1.2 is supported.
